### PR TITLE
Improve news layout and author info

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,15 @@
+---
+layout: default
+---
+
+<article class="container" style="margin: 2rem 0;">
+  <h1>{{ page.title }}</h1>
+  {% if page.git_author or page.git_date %}
+  <p class="date">
+    {% if page.git_author %}by {{ page.git_author }}{% endif %}
+    {% if page.git_date %}{% if page.git_author %} on {% endif %}{{ page.git_date | date: "%B %d, %Y" }}{% endif %}
+  </p>
+  {% endif %}
+
+  {{ content }}
+</article>

--- a/_plugins/git_info.rb
+++ b/_plugins/git_info.rb
@@ -1,0 +1,26 @@
+require "time"
+module Jekyll
+  class GitInfoGenerator < Generator
+    priority :lowest
+    def generate(site)
+      return unless git_present?
+      site.posts.docs.each do |post|
+        path = post.path
+        author = git_command("git log -1 --format=%an -- " + path)
+        date = git_command("git log -1 --format=%ad --date=iso -- " + path)
+        post.data['git_author'] = author unless author.empty?
+        post.data['git_date'] = Time.parse(date) rescue nil unless date.empty?
+      end
+    end
+
+    private
+
+    def git_present?
+      system('git rev-parse --is-inside-work-tree > /dev/null 2>&1')
+    end
+
+    def git_command(cmd)
+      `#{cmd}`.strip
+    end
+  end
+end

--- a/news.html
+++ b/news.html
@@ -14,7 +14,10 @@ title: "news"
       {% for post in site.posts %}
         <article>
           <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
-          <p class="date">{{ post.date | date: "%B %d, %Y" }}</p>
+          <p class="date">
+            {% if post.git_author %}{{ post.git_author }} - {% endif %}
+            {% if post.git_date %}{{ post.git_date | date: "%B %d, %Y" }}{% else %}{{ post.date | date: "%B %d, %Y" }}{% endif %}
+          </p>
           <p>{{ post.excerpt }}</p>
           <p><a href="{{ post.url }}">read more</a></p>
         </article>


### PR DESCRIPTION
## Summary
- add new `post` layout inheriting from `default`
- display git commit author/date via custom plugin
- show commit info in news listing

## Testing
- `jekyll build` *(fails: jekyll not installed)*